### PR TITLE
fix: modify wait conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
 
 .EXPORT_ALL_VARIABLES:
 
-##@ Kind
+##@ Scenario
 
 .PHONY: all-up
-all-up: cluster-up tetragon-install redpanda spark vector ssh-install rbac sc-deploy  port-forward ## Create the kind cluster and deploy tetragon
+all-up: cluster-up tetragon-install redpanda spark vector ssh-install rbac sc-deploy port-forward ## Create the kind cluster and deploy tetragon
 
 .PHONY: detect-on
 detect-on: traces
@@ -17,42 +17,46 @@ detect-on: traces
 ## Run this in a second shell to observe the STDOUT
 .PHONY: secondshell-on
 secondshell-on: 
-	-kubectl logs -n kube-system -l app.kubernetes.io/name=tetragon -c export-stdout -f |\
-	jq 'select( .process_kprobe != null  \
-	        and .process_kprobe.process.pod.namespace != "jupyter"   \
-			and .process_kprobe.process.pod.namespace != "cert-manager" \
-			and .process_kprobe.process.pod.namespace != "redpanda" \
-			and .process_kprobe.process.pod.namespace != "spark" \
-			and .process_kprobe.process.pod.namespace != "parseable" \
-			and .process_kprobe.process.pod.namespace != "vector" )| \
-	 "\(.time) \(.process_kprobe.policy_name) \(.process_kprobe.function_name) \(.process_kprobe.process.binary) \(.process_kprobe.process.arguments) \(.process_kprobe.process.pod.namespace) \(.process_kprobe.args[] | select(.sock_arg != null) | .sock_arg)"'
+	-kubectl logs -n kube-system -l app.kubernetes.io/name=tetragon -c export-stdout -f | \
+	jq 'select( .process_kprobe != null and .process_kprobe.process.pod.namespace == "default" ) | "\(.time) \(.process_kprobe.policy_name) \(.process_kprobe.function_name) \(.process_kprobe.process.binary) \(.process_kprobe.process.arguments) \(.process_kprobe.process.pod.namespace) \(.process_kprobe.args[] | select(.sock_arg != null) | .sock_arg)"'
 
 
 .PHONY: jquery-traces1
 jquery-traces1:
-	-kubectl logs -n kube-system -l app.kubernetes.io/name=tetragon -c export-stdout -f |\
-	jq 'select( .process_kprobe != null  \
-	        and .process_kprobe.process.pod.namespace != "jupyter"   \
-			and .process_kprobe.process.pod.namespace != "cert-manager" \
-			and .process_kprobe.process.pod.namespace != "redpanda" \
-			and .process_kprobe.process.pod.namespace != "spark" \
-			and .process_kprobe.process.pod.namespace != "parseable" \
-			and .process_kprobe.process.pod.namespace != "vector" )| \
-	 "\(.time) \(.process_kprobe.policy_name) \(.process_kprobe.function_name) \(.process_kprobe.process.binary) \(.process_kprobe.process.arguments) \(.process_kprobe.process.pod.namespace) \(.process_kprobe.args[] | select(.sock_arg.priority != null) | .sock_arg.priority)"'
-
+	-kubectl logs -n kube-system -l app.kubernetes.io/name=tetragon -c export-stdout -f | \
+	jq 'select( .process_kprobe != null and .process_kprobe.process.pod.namespace == "default" ) | "\(.time) \(.process_kprobe.policy_name) \(.process_kprobe.function_name) \(.process_kprobe.process.binary) \(.process_kprobe.process.arguments) \(.process_kprobe.process.pod.namespace) \(.process_kprobe.args[] | select(.sock_arg.priority != null) | .sock_arg.priority)"'
 
 .PHONY: attack
 attack: copy-scripts create-bad exec
+
+.PHONY: teardown
+teardown: stop-port-forwarding sc-delete cluster-down
 
 ##@ Kind
 
 .PHONY: cluster-up
 cluster-up: kind ## Create the kind cluster
-	-$(KIND) create cluster --name $(CLUSTER_NAME) 
+	-$(KIND) create cluster --name $(CLUSTER_NAME) --config config/kind-config.yaml
 
 .PHONY: cluster-down
 cluster-down: kind ## Delete the kind cluster
+	-$(HELM) uninstall vector -n vector
+	-$(HELM) uninstall redpanda-src -n redpanda
+	-$(HELM) uninstall cert-manager -n cert-manager
+	-$(HELM) uninstall tetragon -n kube-system
+	-sleep 10
 	-$(KIND) delete cluster --name $(CLUSTER_NAME)
+
+.PHONY: stop-port-forwarding
+stop-port-forwarding:
+	-lsof -ti:5555 | xargs kill -9
+
+.PHONY: sc-delete
+sc-delete:
+	kubectl delete po bad-pv-pod
+	kubectl delete pvc bad-pv-claim-vol 
+	kubectl delete pv bad-pv-volume-vol
+	kubectl delete sc local-storage
 
 
 .PHONY: redpanda
@@ -63,14 +67,12 @@ redpanda:
 	-$(HELM) repo add redpanda https://charts.redpanda.com
 	-$(HELM) repo update
 	-$(HELM) upgrade --install redpanda-src redpanda/redpanda -n redpanda --create-namespace --values redpanda/values.yaml
+	while [ "$$(kubectl -n redpanda get po -l app.kubernetes.io/name=redpanda -o jsonpath='{.items[0].metadata.generateName}')" != "redpanda-src-" ]; do \
+		sleep 5; \
+   	echo "Waiting for Redpanda pod to be created."; \
+	done
+	-kubectl -n redpanda wait --timeout=30s --for=condition=Ready pod -l app.kubernetes.io/component=redpanda-statefulset
 	-kubectl exec -it -n redpanda redpanda-src-0 -c redpanda -- /bin/bash -c "rpk topic create cr1"
-# rpk topic create cr1 | echo "hi" | rpk topic produce cr1
-#-watch -n 1 kubectl get all -A -o wide --field-selector=metadata.namespace=redpanda
-
-#export REDPANDA_BROKERS=localhost:19092
-#for i in {1..60}; do echo $(cat /dev/urandom | head -c10 | base64) | rpk topic produce telemetryB; sleep 1; done
-
-
 
 .PHONY: spark
 spark:
@@ -81,12 +83,6 @@ spark:
 	-$(HELM) repo update
 	-$(HELM) upgrade --install jupyterhub jupyterhub/jupyterhub --namespace jupyter --create-namespace  --values jupyterhub/values.yaml
 	-echo "JHUB user/pass is yours to freely choose"
-
-.PHONY: fluent 
-fluent:
-	-$(HELM) repo add fluent https://fluent.github.io/helm-charts
-	-$(HELM) repo update
-	-$(HELM) upgrade --install fluentd fluent/fluentd -n redpanda --create-namespace --values fluentd/values.yaml
 
 # This is only for CR cause the Registration Code wont work for anyone else
 .PHONY: spyder
@@ -106,17 +102,22 @@ tetragon-install: helm
 	-$(HELM) repo add cilium https://helm.cilium.io
 	-$(HELM) repo update
 	-$(HELM) upgrade --install tetragon cilium/tetragon -n kube-system --set tetragon.grpc.enabled=true --set tetragon.grpc.address=localhost:54321
-	kubectl -n kube-system wait --for=condition=Ready pod  -l app.kubernetes.io/name=tetragon
+	while [ "$$(kubectl -n kube-system get po -l app.kubernetes.io/name=tetragon -o jsonpath='{.items[0].metadata.generateName}')" != "tetragon-" ]; do \
+		sleep 5; \
+   	echo "Waiting for Tetragon pod to be created."; \
+	done
+	-kubectl -n kube-system wait --timeout=120s --for=condition=Ready pod -l app.kubernetes.io/name=tetragon
 
 
 .PHONY: vector
 vector:
 	-$(HELM) repo add vector https://helm.vector.dev
 	-$(HELM) upgrade --install vector vector/vector --namespace vector --create-namespace --values vector/values.yaml
-	-$(HELM) repo add parseable https://charts.parseable.com
-	-$(HELM) upgrade --install parseable parseable/parseable -n parseable --set "parseable.local=true" --create-namespace
-	-kubectl create secret generic parseable-env-secret --from-env-file=parseable/parseable-env-secret -n parseable || echo "pass"
-    #kubectl port-forward svc/parseable 8000:80 -n parseable
+	while [ "$$(kubectl -n vector get po -l app.kubernetes.io/name=vector -o jsonpath='{.items[0].metadata.generateName}')" != "vector-" ]; do \
+		sleep 5; \
+   	echo "Waiting for Vector pod to be created."; \
+	done
+	-kubectl -n vector wait --timeout=120s --for=condition=Ready pod -l app.kubernetes.io/name=vector
 
 .PHONY: traces
 traces:
@@ -141,7 +142,7 @@ traces-off:
 .PHONY: create-bad
 create-bad:
 	ssh -p 5555 -t root@127.0.0.1  'source priv-create.sh'
-	-kubectl wait --for=condition=Ready pod -l app=bad-pv-pod
+	-kubectl wait --for=condition=Ready pod bad-pv-pod
 ##@ vcluster setup
 
 .PHONY: vcluster-deploy
@@ -159,7 +160,7 @@ kyverno-install:
 .PHONY: ssh-install
 ssh-install:
 	-kubectl apply -f insecure-ssh/insecure-ssh.yaml
-	-kubectl -n default wait --for=condition=Ready pod -l app.kubernetes.io/name=ssh-honeypot
+	-kubectl -n default wait --timeout=120s --for=condition=Ready pod -l app.kubernetes.io/name=ssh-honeypot
 
 .PHONY: vcluster-disconnect
 vcluster-disconnect: vcluster
@@ -192,6 +193,7 @@ ssh-connect:
 .PHONY: exec 
 exec:
 	-kubectl exec bad-pv-pod  -- /bin/bash -c "cd /hostlogs/pods/default_bad-pv-**/bad-pv-pod/ && rm  0.log && ln -s /etc/kubernetes/pki/apiserver.key 0.log"
+	-kubectl logs bad-pv-pod
 
 
 ##@ Tools

--- a/README.md
+++ b/README.md
@@ -17,136 +17,53 @@ flowchart TD
 ```
 
 ## Known Issues
-tetragon traces are not all created equal, some need improvments, especially the logs from kafka/fluentd/cert-man etc should be ignored
-fluentd keeps on crashing, needs investigation
-all logs currently go to topic "cr1" on kafka, need filter in fluentd
-need schema
-wait-conditions in make-file are flaky at best, need fine-tuning
-currently vcluster is switched off, kyverno as well -> needs to be retested with those turned on
 
+tetragon traces are not all created equal, some need improvements
 
 ## Demo
 
 Bring all the infra up (known issue: wait conditions):
+
 ```bash
 make all-up
 ```
+
 Put the traces on
+
 ```bash
 make traces
 ```
 
-Go to second shell for STDOUT observations (dont kill this shell)
+You can view the Redpanda dashboard by browsing to: <http://localhost:30000/>
+
+Go to second shell for STDOUT observations (don't kill this shell)
+
 ```bash
 make secondshell-on
 ```
-Back to first shell, run
+
+Go back to the first shell, and run the attack which will make an SSH connection to our vulnerable server, run a malicious script which will create a HostPath type PersistentVolume, allowing a pod to access `/var/log` on the host (inspired by [this blog post](https://jackleadford.github.io/containers/2020/03/06/pvpost.html)), using the [Python Kubernetes client library](https://github.com/kubernetes-client/python):
+
 ```bash
 make attack
 ```
 
+When prompted, the password is `root`.
 
-Spin up a kind cluster:
-
-```bash
-make cluster-up
-```
-
-Install [Tetragon](https://tetragon.io/):
-
-```bash
-make tetragon-install
-```
-
-Set up a [vcluster](https://www.vcluster.com/) within our kind cluster where our honeypot workloads will run:
-
-```bash
-make vcluster-deploy
-```
-
-Install [Kyverno](https://kyverno.io/) and enforce baseline Pod Security Standards across the cluster:
-
-```bash
-make kyverno-install
-```
-
-Install an intentionally vulnerable SSH server:
-
-```bash
-make ssh-install
-```
-
-Deploy a local storage class for our vcluster:
-
-```bash
-make sc-deploy
-```
-
-Set up a potentially dangerous Cluster Role and Cluster Role Binding enabling a default Service Account to create pods, persistent volumes, and persistent volume claims:
-
-```bash
-make rbac
-```
-
-Set up port forwarding to our SSH server:
-
-```bash
-make port-forward
-```
-
-Switch to a new terminal tab and copy some scripts over to the SSH server. The password is `root`. This represents initial attacker access to our honeypot cluster, via credential compromise:
-
-```bash
-make copy-scripts
-```
-
-SSH into the server using the same password:
-
-```bash
-make ssh-connect
-```
-
-From within the SSH session, run a malicious script which will create a HostPath type PersistentVolume which will allow a pod to access `/var/log` on the host (inspred by [this blog post](https://jackleadford.github.io/containers/2020/03/06/pvpost.html)), using the [Python Kubernetes client library](https://github.com/kubernetes-client/python):
-
-```bash
-source priv-create.sh
-```
-
-Switch to a new terminal tab and observe the dangerous pod running:
-
-```bash
-kubectl get po
-```
-
-Let's show that an attacker could use this pod to read arbitrary information from a node in the cluster (in this case we will read the K8s API server's private key). Exec into the pod:
-
-```bash
-make exec
-```
-
-Run the following from within the pod to write a symlink to its `0.log` file, which is followed by the Node upon `kubectl logs PODNAME` in order to read any file from the Node. `cd` into the directory `/hostlogs/pods/vcluster_bad-pv-pod_......../bad-pv-pod/` and run the following:
-
-```bash
-rm 0.log && ln -s /etc/kubernetes/pki/apiserver.key 0.log
-```
-
-If the service account compromised by our attacker could inspect the logs of the containers it can create, the attacker could now run:
-
-```bash
-k logs bad-pv-pod --tail=-1
-```
-
-Note that we can see the first line of the private key.
+If the service account compromised by our attacker could inspect the logs of the containers it can create, running `kubectl logs bad-pv-pod --tail=-1` (or making an API call from within the bad pod) will enable an attacker to view arbitrary files (line by line) on the host. In this example, we have a single node cluster, so we can access control plane data.
 
 ## Teardown
 
 ```bash
-make cluster-down
+make teardown
 ```
 
 ## Note for Mac Users
-Certain Docker Desktop versions will lead to the following error 
-```
+
+Certain Docker Desktop versions will lead to the following error:
+
+```text
 level=fatal msg="Load overlay network failed" error="program cil_from_overlay: replacing clsact qdisc for interface cilium_vxlan: operation not supported" interface=cilium_vxlan subsys=datapath-loader
 ```
-downgrading or using an alternative (Orbstack) will solve this . 
+
+downgrading or using an alternative (Orbstack) will solve this.

--- a/config/kind-config.yaml
+++ b/config/kind-config.yaml
@@ -1,9 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  disableDefaultCNI: true # disable kindnet
 nodes:
 - role: control-plane
-- role: worker
-- role: worker
-- role: worker
+  extraPortMappings:
+    - containerPort: 30000
+      hostPort: 30000

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -154,6 +154,10 @@ console:
   deployment:
     create: false
   config: {}
+  service:
+    type: "NodePort"
+    port: 8080
+    nodePort: 30000
 
 #
 # -- Redpanda Managed Connectors settings


### PR DESCRIPTION
- modify wait conditions so that everything spins up with make all-up
- delete resources on teardown, fixing problems with kind cluster deletion
- shorten jq command by filtering on namespace==default
- remove line breaks in the middle of jq command which were causing issues for me
- clean up README
- add extra port mappings to kind config, allowing services to be exposed via nodeport for kind demo
- add nodeport for redpanda console, removing need to port forward for demo