### PR TITLE
feat: automate signal minus baseline on kind

### DIFF
--- a/insecure-ssh/insecure-ssh.yaml
+++ b/insecure-ssh/insecure-ssh.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: ssh-proxy
-      image: jamescallaghan1987/insecure_ssh:latest
+      image: entlein/ssh-proxy:0.0.3
       imagePullPolicy: Always
       ports:
         - name: ssh-port

--- a/insecure-ssh/insecure-ssh.yaml
+++ b/insecure-ssh/insecure-ssh.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: ssh-proxy
-      image: entlein/ssh-proxy:0.0.3
+      image: jamescallaghan1987/insecure_ssh:latest
       imagePullPolicy: Always
       ports:
         - name: ssh-port
@@ -26,5 +26,5 @@ spec:
   - port: 22
     targetPort: 22
   selector:
-    app: ssh-proxy
+    app.kubernetes.io/name: ssh-proxy
 

--- a/redpanda/kind-smb/keys/go.mod
+++ b/redpanda/kind-smb/keys/go.mod
@@ -1,0 +1,3 @@
+module keys
+
+go 1.21.7

--- a/redpanda/kind-smb/keys/keys.go
+++ b/redpanda/kind-smb/keys/keys.go
@@ -1,0 +1,35 @@
+package keys
+
+redpandaContainerId := "REDPANDA_CONTAINER_ID"
+
+var Baselinekeys = []string{
+	redpandaContainerId + "usrbinbashusrbinrpkclusterhealth",
+	redpandaContainerId + "usrbincurlsilentfailkhttpredpandasrc0redpandasrcredpandasvcclusterlocal9644v1statusready",
+	redpandaContainerId + "binshccurlsilentfailkhttp{SERVICE_NAME}redpandasrcredpandasvcclusterlocal9644v1statusready",
+	redpandaContainerId + "binshccurlsilentfailkhttp{SERVICENAME}redpandasrcredpandasvcclusterlocal9644v1statusready",
+	redpandaContainerId + "optredpandalibexecrpkclusterhealth",
+	redpandaContainerId + "binbashcrpktopiccreateextractcsv",
+	redpandaContainerId + "usrbinrpkbashusrbinrpktopiccreateextractcsv",
+	redpandaContainerId + "usrbinbashusrbinrpktopiccreateextractcsv",
+	redpandaContainerId + "optredpandalibexecrpktopiccreateextractcsv",
+	redpandaContainerId + "binbashcrpktopiccreatebaseline",
+	redpandaContainerId + "usrbinrpkbashusrbinrpktopiccreatebaseline",
+	redpandaContainerId + "usrbinbashusrbinrpktopiccreatebaseline",
+	redpandaContainerId + "optredpandalibexecrpktopiccreatebaseline",
+	redpandaContainerId + "binbashcrpktopiccreatesignalminusbaseline",
+	redpandaContainerId + "usrbinrpkbashusrbinrpktopiccreatesignalminusbaseline",
+	redpandaContainerId + "usrbinbashusrbinrpktopiccreatesignalminusbaseline",
+	redpandaContainerId + "optredpandalibexecrpktopiccreatesignalminusbaseline",
+	redpandaContainerId + "binbashcrpktopiccreatetetragon",
+	redpandaContainerId + "usrbinrpkbashusrbinrpktopiccreatetetragon",
+	redpandaContainerId + "usrbinbashusrbinrpktopiccreatetetragon",
+	redpandaContainerId + "optredpandalibexecrpktopiccreatetetragon",
+	redpandaContainerId + "binbashcrpktopiccreatekind-smb",
+	redpandaContainerId + "usrbinrpkbashusrbinrpktopiccreatekind-smb",
+	redpandaContainerId + "usrbinbashusrbinrpktopiccreatekind-smb",
+	redpandaContainerId + "optredpandalibexecrpktopiccreatekind-smb",
+	redpandaContainerId + "binbashcmkdirptmpbaseline",
+	redpandaContainerId + "usrbinmkdirptmpbaseline",
+	redpandaContainerId + "usrbintestdtmpbaseline",
+	redpandaContainerId + "usrbintarxmfCtmpbaseline",
+}

--- a/redpanda/kind-smb/keys/keys.go
+++ b/redpanda/kind-smb/keys/keys.go
@@ -1,6 +1,6 @@
 package keys
 
-redpandaContainerId := "REDPANDA_CONTAINER_ID"
+var redpandaContainerId = "REDPANDA_CONTAINER_ID"
 
 var Baselinekeys = []string{
 	redpandaContainerId + "usrbinbashusrbinrpkclusterhealth",

--- a/redpanda/kind-smb/transform/go.mod
+++ b/redpanda/kind-smb/transform/go.mod
@@ -1,0 +1,10 @@
+module transform
+
+go 1.21.7
+
+replace keys => ../keys
+
+require (
+	github.com/redpanda-data/redpanda/src/transform-sdk/go/transform v0.2.0
+	keys v0.0.0-00010101000000-000000000000
+)

--- a/redpanda/kind-smb/transform/go.sum
+++ b/redpanda/kind-smb/transform/go.sum
@@ -1,0 +1,2 @@
+github.com/redpanda-data/redpanda/src/transform-sdk/go/transform v0.2.0 h1:CO3Iv/8nMet1+0PGLcxPxmHJOS9P/z6W08e9HYRSbz4=
+github.com/redpanda-data/redpanda/src/transform-sdk/go/transform v0.2.0/go.mod h1:QGgiwwf/BIsD1b7EiyQ/Apzw+RLSpasRDdpOCiefQFQ=

--- a/redpanda/kind-smb/transform/transform.go
+++ b/redpanda/kind-smb/transform/transform.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"keys"
+
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/transform"
+)
+
+func main() {
+	// Register your transform function.
+	// This is a good place to perform other setup too.
+	keysSet = make(map[string]struct{}, len(bkeys))
+	for _, key := range bkeys {
+		keysSet[key] = struct{}{}
+	}
+	transform.OnRecordWritten(doTransform)
+}
+
+type Message struct {
+	Timestamp string                 `json:"timestamp"`
+	Data      map[string]interface{} `json:",inline"`
+}
+
+// To create the "hash" of a known message, focused on avoiding false negatives
+
+var topLevelFields = []string{"process_exec", "process_exit", "process_kprobe"}
+var subFieldsToConcatenate = []string{"process.pod.container.id", "process.binary", "process.arguments"}
+
+func createKey(incomingMessage map[string]interface{}) string {
+	var keyParts []string
+
+	for _, topLevelField := range topLevelFields {
+		if value, ok := incomingMessage[topLevelField]; ok {
+			// If the top-level field exists, traverse its subfields
+			for _, subField := range subFieldsToConcatenate {
+				// Split the subfield into parts
+				parts := strings.Split(subField, ".")
+				subValue := value.(map[string]interface{})
+				for _, part := range parts {
+					// Traverse the map
+					if v, ok := subValue[part]; ok {
+						// If the part exists, add it to the key parts
+						switch v := v.(type) {
+						case map[string]interface{}:
+							subValue = v
+						default:
+							keyParts = append(keyParts, fmt.Sprint(v))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Join the key parts with a separator
+	key := strings.Join(keyParts, "")
+	// Remove all whitespaces and escape characters
+	key = strings.ReplaceAll(key, " ", "")
+	key = strings.ReplaceAll(key, "\\", "")
+	key = strings.ReplaceAll(key, "/", "")
+	key = strings.ReplaceAll(key, "\"", "")
+	key = strings.ReplaceAll(key, "'", "")
+	key = strings.ReplaceAll(key, "-", "")
+	key = strings.ReplaceAll(key, "/", "")
+	key = strings.ReplaceAll(key, "=", "")
+	key = strings.ReplaceAll(key, ".", "")
+	key = strings.ReplaceAll(key, "containerd", "")
+	key = strings.ReplaceAll(key, ":", "")
+	key = strings.ReplaceAll(key, "+", "")
+	key = strings.ReplaceAll(key, "$", "")
+	key = strings.ReplaceAll(key, "_", "")
+
+	return key
+}
+
+var bkeys = keys.Baselinekeys
+
+var keysSet map[string]struct{}
+
+func doTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	// Unmarshal the incoming message into a map
+	record := e.Record()
+	if strings.Contains(string(record.Value), "/var/lib/rancher-data/local-catalogs/v2/rancher") {
+		return nil
+	}
+
+	var incomingMessage map[string]interface{}
+	err := json.Unmarshal(e.Record().Value, &incomingMessage)
+	if err != nil {
+		return err
+	}
+
+	// Extract 3 fields from the JSON and concat them as key
+	key := createKey(incomingMessage)
+
+	// Check if the key is in the CSV keys
+	if _, ok := keysSet[key]; !ok {
+		// If the key is not in the CSV keys, write the message
+
+		// Marshal the result back to JSON
+		jsonData, err := json.Marshal(incomingMessage)
+		if err != nil {
+			return err
+		}
+
+		// Create a new record with the JSON data
+		record := &transform.Record{
+			Key:       []byte(key),
+			Value:     jsonData,
+			Offset:    e.Record().Offset,
+			Timestamp: e.Record().Timestamp,
+			Headers:   e.Record().Headers,
+		}
+
+		// Write the record to the destination topic
+		err = w.Write(*record)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/redpanda/kind-smb/transform/transform.yaml
+++ b/redpanda/kind-smb/transform/transform.yaml
@@ -1,0 +1,4 @@
+name: kind-smb
+input-topic: "cr1"
+output-topic: "kind-smb"
+language: tinygo-no-goroutines


### PR DESCRIPTION
- create 'kind-smb' transform
- separate out 'baseline keys' into separate local golang 'keys' package
- introduce new target 'redpanda-kind-wasm' in makefile to automatically fetch container IDs from containerd logs in the kind node, and put the ids into the keys package, and build the transform
- remove the container id once the transform has been built, to be ready for the next ephemeral kind cluster to be spun up (with new container IDs)